### PR TITLE
feat: Add `union` function to combine multiple graphs

### DIFF
--- a/rdgc/graph/__init__.py
+++ b/rdgc/graph/__init__.py
@@ -5,7 +5,15 @@ This module provides utilities for creating and manipulating graphs.
 from typing import Any, Callable, Dict
 
 from rdgc.graph.base import Graph
-from rdgc.graph.utils import null, complete, tournament, random_graph, cycle, wheel
+from rdgc.graph.utils import (
+    null,
+    complete,
+    tournament,
+    random_graph,
+    cycle,
+    wheel,
+    union,
+)
 from rdgc.graph.tree import chain, star, tree, binary_tree, spanning_tree
 from rdgc.graph.degree import from_degree_sequence, k_regular
 from rdgc.graph.connected import connected, strongly_connected
@@ -25,6 +33,7 @@ __all__ = [
     "spanning_tree",
     "cycle",
     "wheel",
+    "union",
     "connected",
     "strongly_connected",
     "from_degree_sequence",

--- a/rdgc/graph/base.py
+++ b/rdgc/graph/base.py
@@ -198,18 +198,20 @@ class Graph:
         return self.__outdeg_counter[u]
 
     def get_edges(
-        self, u: Optional[int] = None, *, directed: Optional[bool] = None
+        self, u: Optional[int] = None, *, directed: bool = False
     ) -> Generator[Tuple[int, int, Any], None, None]:
         """
         Returns an iterator over the edges of the graph.
 
         Args:
             u (int, optional): If specified, returns edges incident to vertex `u`. Defaults to None.
+            directed (bool): Only works if the graph is undirected.
+                If True, returns directed edges. Defaults to False.
 
         Yields:
             Tuple[int, int, Any]: A tuple containing the vertices and weight of an edge.
         """
-        directed = self.__directed if directed is None else directed
+        directed = self.__directed or directed
         if u is None:
             for uu in range(self.vertices):
                 for vv, weight in self.__adjacency_list[uu]:

--- a/rdgc/graph/base.py
+++ b/rdgc/graph/base.py
@@ -198,7 +198,7 @@ class Graph:
         return self.__outdeg_counter[u]
 
     def get_edges(
-        self, u: Optional[int] = None
+        self, u: Optional[int] = None, *, directed: Optional[bool] = None
     ) -> Generator[Tuple[int, int, Any], None, None]:
         """
         Returns an iterator over the edges of the graph.
@@ -209,10 +209,11 @@ class Graph:
         Yields:
             Tuple[int, int, Any]: A tuple containing the vertices and weight of an edge.
         """
+        directed = self.__directed if directed is None else directed
         if u is None:
             for uu in range(self.vertices):
                 for vv, weight in self.__adjacency_list[uu]:
-                    if self.directed or uu <= vv:
+                    if directed or uu <= vv:
                         yield uu, vv, weight
         else:
             for v, weight in self.__adjacency_list[u]:

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -207,6 +207,22 @@ class TestGraph(unittest.TestCase):
                 self.assertEqual(graph.count_edge(0, u), 1)
                 self.assertEqual(graph.count_edge(u, u % (N - 1) + 1), 1)
 
+    def test_union(self):
+        N = 4
+        graph1 = complete(N)
+        graph2 = chain(N)
+        graph = union(
+            graph1,
+            graph2,
+            node_mapping=lambda nid, gid, gs: nid if gid == 0 else nid + N - 1,
+        )
+        self.assertEqual(graph.vertices, 2 * N - 1)
+        self.assertEqual(graph.edges, graph1.edges + graph2.edges)
+        self.assertEqual(
+            graph.output_edges(),
+            "0 1\n" "0 2\n" "0 3\n" "1 2\n" "1 3\n" "2 3\n" "3 4\n" "4 5\n" "5 6",
+        )
+
     def test_degree_unmutiedge(self):
         N = 20
         for _ in range(40):

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -211,11 +211,7 @@ class TestGraph(unittest.TestCase):
         N = 4
         graph1 = complete(N)
         graph2 = chain(N)
-        graph = union(
-            graph1,
-            graph2,
-            node_mapping=lambda nid, gid, gs: nid if gid == 0 else nid + N - 1,
-        )
+        graph = union(graph1, graph2, default_mapping="connect")
         self.assertEqual(graph.vertices, 2 * N - 1)
         self.assertEqual(graph.edges, graph1.edges + graph2.edges)
         self.assertEqual(


### PR DESCRIPTION
+ 允许在 get_edges 中指定 `directed` 参数，以将无向图按有向图方式输出。
+ 在 `graph/utils.py` 中定义 `union` 函数，以将多个图组合为一个图。